### PR TITLE
feat: dump deprecation warning when importing prepacked_queries modules

### DIFF
--- a/ebr_connector/prepacked_queries/__init__.py
+++ b/ebr_connector/prepacked_queries/__init__.py
@@ -5,3 +5,6 @@ prepacked queries
 import warnings
 
 warnings.warn("prepacked_queries are deprecated", DeprecationWarning, stacklevel=2)
+
+
+DEPRECATION_MESSAGE = "The prepacked_queries modules will be removed. A replacement is under consideration but not guaranteed."

--- a/ebr_connector/prepacked_queries/__init__.py
+++ b/ebr_connector/prepacked_queries/__init__.py
@@ -1,0 +1,7 @@
+"""
+prepacked queries
+"""
+
+import warnings
+
+warnings.warn("prepacked_queries are deprecated", DeprecationWarning, stacklevel=2)

--- a/ebr_connector/prepacked_queries/multi_jobs.py
+++ b/ebr_connector/prepacked_queries/multi_jobs.py
@@ -1,10 +1,14 @@
 """
 A collection of queries that provide multiple results as an array of dicts
 """
+
+import warnings
 from elasticsearch_dsl import Q, A
 
 from ebr_connector.schema.build_results import BuildResults
 from ebr_connector.prepacked_queries.query import make_query, DETAILED_JOB, JOB_MINIMAL
+
+warnings.warn("prepacked_queries: the multi_jobs module is deprecated", DeprecationWarning, stacklevel=2)
 
 def successful_jobs(index, job_name_regex, size=10, start_date="now-7d", end_date="now"):
     """

--- a/ebr_connector/prepacked_queries/multi_jobs.py
+++ b/ebr_connector/prepacked_queries/multi_jobs.py
@@ -6,10 +6,11 @@ from elasticsearch_dsl import Q, A
 from deprecated.sphinx import deprecated
 
 from ebr_connector.schema.build_results import BuildResults
+from ebr_connector.prepacked_queries import DEPRECATION_MESSAGE
 from ebr_connector.prepacked_queries.query import make_query, DETAILED_JOB, JOB_MINIMAL
 
 
-@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
+@deprecated(version="0.1.1", reason=DEPRECATION_MESSAGE)
 def successful_jobs(index, job_name_regex, size=10, start_date="now-7d", end_date="now"):
     """
     Get the results of jobs matching the job name regex provided.
@@ -36,7 +37,7 @@ def successful_jobs(index, job_name_regex, size=10, start_date="now-7d", end_dat
     return result
 
 
-@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
+@deprecated(version="0.1.1", reason=DEPRECATION_MESSAGE)
 def failed_tests(index, job_name, size=10, fail_count=5, duration_low=162.38, duration_high=320, start_date="now-7d", end_date="now", agg=False): #pylint: disable=too-many-locals
     """
     Get jobs with failed tests matching certain parameters
@@ -79,7 +80,7 @@ def failed_tests(index, job_name, size=10, fail_count=5, duration_low=162.38, du
     return make_query(index, combined_filter, includes=DETAILED_JOB['includes'], excludes=DETAILED_JOB['excludes'], size=size, agg=test_agg)
 
 
-@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
+@deprecated(version="0.1.1", reason=DEPRECATION_MESSAGE)
 def job_matching_test(index, test_name, passed=True, failed=True, skipped=False, job_name=None, size=10, start_date="now-7d", end_date="now"):
     """
     Get information on a given test
@@ -124,7 +125,7 @@ def job_matching_test(index, test_name, passed=True, failed=True, skipped=False,
     return make_query(index, combined_filter, includes=JOB_MINIMAL['includes'], excludes=JOB_MINIMAL['excludes'], size=size)
 
 
-@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
+@deprecated(version="0.1.1", reason=DEPRECATION_MESSAGE)
 def get_job(index, job_name, wildcard=False, size=10, start_date="now-7d", end_date="now"):
     """
     Get a list of all the builds recorded for a given job

--- a/ebr_connector/prepacked_queries/multi_jobs.py
+++ b/ebr_connector/prepacked_queries/multi_jobs.py
@@ -2,14 +2,14 @@
 A collection of queries that provide multiple results as an array of dicts
 """
 
-import warnings
 from elasticsearch_dsl import Q, A
+from deprecated.sphinx import deprecated
 
 from ebr_connector.schema.build_results import BuildResults
 from ebr_connector.prepacked_queries.query import make_query, DETAILED_JOB, JOB_MINIMAL
 
-warnings.warn("prepacked_queries: the multi_jobs module is deprecated", DeprecationWarning, stacklevel=2)
 
+@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
 def successful_jobs(index, job_name_regex, size=10, start_date="now-7d", end_date="now"):
     """
     Get the results of jobs matching the job name regex provided.
@@ -35,6 +35,8 @@ def successful_jobs(index, job_name_regex, size=10, start_date="now-7d", end_dat
     result = make_query(index, combined_filter, includes=DETAILED_JOB['includes'], excludes=DETAILED_JOB['excludes'], size=size)
     return result
 
+
+@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
 def failed_tests(index, job_name, size=10, fail_count=5, duration_low=162.38, duration_high=320, start_date="now-7d", end_date="now", agg=False): #pylint: disable=too-many-locals
     """
     Get jobs with failed tests matching certain parameters
@@ -76,6 +78,8 @@ def failed_tests(index, job_name, size=10, fail_count=5, duration_low=162.38, du
 
     return make_query(index, combined_filter, includes=DETAILED_JOB['includes'], excludes=DETAILED_JOB['excludes'], size=size, agg=test_agg)
 
+
+@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
 def job_matching_test(index, test_name, passed=True, failed=True, skipped=False, job_name=None, size=10, start_date="now-7d", end_date="now"):
     """
     Get information on a given test
@@ -119,6 +123,8 @@ def job_matching_test(index, test_name, passed=True, failed=True, skipped=False,
 
     return make_query(index, combined_filter, includes=JOB_MINIMAL['includes'], excludes=JOB_MINIMAL['excludes'], size=size)
 
+
+@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
 def get_job(index, job_name, wildcard=False, size=10, start_date="now-7d", end_date="now"):
     """
     Get a list of all the builds recorded for a given job

--- a/ebr_connector/prepacked_queries/query.py
+++ b/ebr_connector/prepacked_queries/query.py
@@ -4,6 +4,7 @@ Module with basic wrapper for making a query to elastic search, as well as defau
 
 from deprecated.sphinx import deprecated
 from ebr_connector.schema.build_results import BuildResults
+from ebr_connector.prepacked_queries import DEPRECATION_MESSAGE
 
 
 # Provides common job details, without all passing and skipped tests
@@ -40,7 +41,7 @@ JOB_MINIMAL = {
 }
 
 
-@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
+@deprecated(version="0.1.1", reason=DEPRECATION_MESSAGE)
 def make_query(index, combined_filter, includes, excludes, agg=None, size=1):
     """
     Simplifies the execution and usage of a typical query, including cleaning up the results.

--- a/ebr_connector/prepacked_queries/query.py
+++ b/ebr_connector/prepacked_queries/query.py
@@ -2,10 +2,9 @@
 Module with basic wrapper for making a query to elastic search, as well as default field lists for including/excluding in results
 """
 
-import warnings
+from deprecated.sphinx import deprecated
 from ebr_connector.schema.build_results import BuildResults
 
-warnings.warn("prepacked_queries: the query module is deprecated", DeprecationWarning, stacklevel=2)
 
 # Provides common job details, without all passing and skipped tests
 DETAILED_JOB = {
@@ -40,6 +39,8 @@ JOB_MINIMAL = {
     ]
 }
 
+
+@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
 def make_query(index, combined_filter, includes, excludes, agg=None, size=1):
     """
     Simplifies the execution and usage of a typical query, including cleaning up the results.

--- a/ebr_connector/prepacked_queries/query.py
+++ b/ebr_connector/prepacked_queries/query.py
@@ -1,7 +1,11 @@
 """
 Module with basic wrapper for making a query to elastic search, as well as default field lists for including/excluding in results
 """
+
+import warnings
 from ebr_connector.schema.build_results import BuildResults
+
+warnings.warn("prepacked_queries: the query module is deprecated", DeprecationWarning, stacklevel=2)
 
 # Provides common job details, without all passing and skipped tests
 DETAILED_JOB = {

--- a/ebr_connector/prepacked_queries/single_jobs.py
+++ b/ebr_connector/prepacked_queries/single_jobs.py
@@ -2,13 +2,13 @@
 Collection of queries that return a single result (in dictionary form)
 """
 
-import warnings
 from elasticsearch_dsl import Q
+from deprecated.sphinx import deprecated
 
 from ebr_connector.prepacked_queries.query import make_query, DETAILED_JOB
 
-warnings.warn("prepacked_queries: the single_jobs module is deprecated", DeprecationWarning, stacklevel=2)
 
+@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
 def get_build(index, job_name, build_id, wildcard=False):
     """
     Get result of a single build from the elastic search database by its ID and the name of the job it belongs to.

--- a/ebr_connector/prepacked_queries/single_jobs.py
+++ b/ebr_connector/prepacked_queries/single_jobs.py
@@ -5,10 +5,11 @@ Collection of queries that return a single result (in dictionary form)
 from elasticsearch_dsl import Q
 from deprecated.sphinx import deprecated
 
+from ebr_connector.prepacked_queries import DEPRECATION_MESSAGE
 from ebr_connector.prepacked_queries.query import make_query, DETAILED_JOB
 
 
-@deprecated(version="0.1.1", reason="It is planned to replace these functions with a DSL")
+@deprecated(version="0.1.1", reason=DEPRECATION_MESSAGE)
 def get_build(index, job_name, build_id, wildcard=False):
     """
     Get result of a single build from the elastic search database by its ID and the name of the job it belongs to.

--- a/ebr_connector/prepacked_queries/single_jobs.py
+++ b/ebr_connector/prepacked_queries/single_jobs.py
@@ -2,9 +2,12 @@
 Collection of queries that return a single result (in dictionary form)
 """
 
+import warnings
 from elasticsearch_dsl import Q
 
 from ebr_connector.prepacked_queries.query import make_query, DETAILED_JOB
+
+warnings.warn("prepacked_queries: the single_jobs module is deprecated", DeprecationWarning, stacklevel=2)
 
 def get_build(index, job_name, build_id, wildcard=False):
     """

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ recommonmark==0.5.0
 Sphinx==2.0.1
 sphinx-rtd-theme==0.4.3
 watchdog==0.9.0
+deprecated==1.2.5
 
 coverage==4.5.3
 pylint==2.3.1


### PR DESCRIPTION
When using a module from the prepacked_queries the result looks like this:

```
tests/unit/schema/test_build_results_document.py:14
  ebr-connector/tests/unit/schema/test_build_results_document.py:14: DeprecationWarning: prepacked_queries are deprecated
    from ebr_connector.prepacked_queries import single_jobs


[...]

 ebr_connector/prepacked_queries/multi_jobs.py:36: DeprecationWarning: Call to deprecated function (or staticmethod) make_query. (The prepacked_queries modules will be removed. A replacement is under consideration but not guaranteed.) -- Deprecated since version 0.1.1.
    result = make_query(index, combined_filter, includes=DETAILED_JOB['includes'], excludes=DETAILED_JOB['excludes'], size=size)
```