### PR TITLE
Pin elasticsearch-dsl to 6.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as readme_file:
 with open("CHANGELOG.md") as changelog_file:
     changelog = changelog_file.read()
 
-requirements = ["elasticsearch-dsl>=6.2.1,<7", "requests>=2.18.4,<3"]
+requirements = ["elasticsearch-dsl==6.3.1", "requests>=2.18.4,<3"]
 
 setup_requirements = ["pytest-runner"]
 


### PR DESCRIPTION
There is a shift in the API of elasticsearch-dsl, pinning it will prevent this from breaking consumers of ebr-connector.